### PR TITLE
v0.0.44: fix negative ints bypassing Min/Max validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to incremental patch versioning (`v0.0.x`).
 
+## [v0.0.44]
+
+A bug-fix release. No public API changes.
+
+### Fixed
+
+- **Negative integers no longer bypass `Min` / `Max` (`WithMin` / `WithMax` / `Between`).** `extractInteger` previously matched digits with the regex `[0-9]+`, which silently dropped the leading sign and concatenated separate digit groups. As a result `-5` was treated as `5`: it passed `WithMin(1)` and was wrongly rejected by `WithMax(3)`. The helper now reads the numeric value directly via reflection (int / uint / float families), correctly preserving sign and magnitude — including large floats that render in scientific notation.
+
+### Internal
+
+- Removed the now-unused `removeAfter` string helper and the `fmt.Sprintf` + `e+` stripping at the integer `Min`/`Max` call sites.
+- Added regression tests: `TestNegativeIntegerFailsWithMin`, `TestNegativeIntegerPassesWithMax`, `TestNegativeIntegerBetween`.
+
+### Migration notes
+
+- No code changes required. Callers that (incorrectly) relied on negative integers passing a positive `Min` will now see those values correctly rejected.
+
 ## [v0.0.43]
 
 All changes are additive on the public API — existing usage patterns keep

--- a/map_validator/functions.go
+++ b/map_validator/functions.go
@@ -936,8 +936,7 @@ func validateValueInternal(data interface{}, validator Rules, dataFrom loadFromT
 				actualLength = int64(total)
 			}
 		} else if isIntegerFamily(dataType) {
-			strData := removeAfter(fmt.Sprintf("%v", data), "e+")
-			num := extractInteger(strData)
+			num := extractInteger(data)
 			if num < *validator.Min {
 				isErr = true
 				actualLength = num
@@ -972,8 +971,7 @@ func validateValueInternal(data interface{}, validator Rules, dataFrom loadFromT
 				actualLength = int64(total)
 			}
 		} else if isIntegerFamily(dataType) {
-			strData := removeAfter(fmt.Sprintf("%v", data), "e+")
-			num := extractInteger(strData)
+			num := extractInteger(data)
 			if num > *validator.Max {
 				isErr = true
 				actualLength = num
@@ -1041,26 +1039,17 @@ func toMapStringInterface(data interface{}) (map[string]interface{}, error) {
 	return res, nil
 }
 
-func removeAfter(data, after string) string {
-	split := strings.Split(data, after)
-	if len(split) > 0 {
-		return split[0]
+func extractInteger(data interface{}) int64 {
+	v := reflect.ValueOf(data)
+	switch v.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int()
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return int64(v.Uint())
+	case reflect.Float32, reflect.Float64:
+		return int64(v.Float())
 	}
-	return data
-}
-
-func extractInteger(data string) int64 {
-	var intStr string
-	re := regexp.MustCompile("[0-9]+")
-	resStr := re.FindAllString(data, -1)
-	for _, val := range resStr {
-		intStr += val
-	}
-	res, err := strconv.ParseInt(intStr, 10, 64)
-	if err != nil {
-		return 0
-	}
-	return res
+	return 0
 }
 
 func convertValue(newValue interface{}, kind reflect.Kind, data reflect.Value, pointer bool) error {

--- a/test/integer_familiy_test.go
+++ b/test/integer_familiy_test.go
@@ -530,6 +530,66 @@ func TestMixedIntegerFamilyEnumWithHttpRequest(t *testing.T) {
 	}
 }
 
+// Test negative integer must fail WithMin (regression: sign stripped by extractInteger)
+func TestNegativeIntegerFailsWithMin(t *testing.T) {
+	dataMap := map[string]interface{}{"qty": -5}
+
+	rules := map_validator.BuildRoles().
+		SetRule("qty", map_validator.Int().WithMin(1))
+
+	op, err := map_validator.NewValidateBuilder().SetRules(rules).Load(dataMap)
+	if err != nil {
+		t.Fatalf("load error: %s", err)
+	}
+
+	_, err = op.RunValidate()
+	if err == nil {
+		t.Fatal("Expected validation to fail for -5 with WithMin(1), but it passed")
+	}
+}
+
+// Test negative integer must pass WithMax (regression: sign stripped made -5 look like 5)
+func TestNegativeIntegerPassesWithMax(t *testing.T) {
+	dataMap := map[string]interface{}{"balance": -5}
+
+	rules := map_validator.BuildRoles().
+		SetRule("balance", map_validator.Int().WithMax(3))
+
+	op, err := map_validator.NewValidateBuilder().SetRules(rules).Load(dataMap)
+	if err != nil {
+		t.Fatalf("load error: %s", err)
+	}
+
+	_, err = op.RunValidate()
+	if err != nil {
+		t.Fatalf("Expected -5 to satisfy WithMax(3), but it failed: %s", err.Error())
+	}
+}
+
+// Test negative range via Between (e.g. temperature -10..10)
+func TestNegativeIntegerBetween(t *testing.T) {
+	rules := map_validator.BuildRoles().
+		SetRule("temp", map_validator.Int().Between(-10, 10))
+
+	// -3 is within range, must pass
+	op, err := map_validator.NewValidateBuilder().SetRules(rules).Load(map[string]interface{}{"temp": -3})
+	if err != nil {
+		t.Fatalf("load error: %s", err)
+	}
+	if _, err = op.RunValidate(); err != nil {
+		t.Fatalf("Expected -3 within [-10,10] to pass, got: %s", err.Error())
+	}
+
+	// -50 is below range, must fail
+	op2, err := map_validator.NewValidateBuilder().SetRules(rules).Load(map[string]interface{}{"temp": -50})
+	if err != nil {
+		t.Fatalf("load error: %s", err)
+	}
+	if _, err = op2.RunValidate(); err == nil {
+		t.Fatal("Expected -50 below [-10,10] to fail, but it passed")
+	}
+}
+
 // Helper function for string contains check (if not already defined elsewhere)
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || indexOfSubstring(s, substr) >= 0)


### PR DESCRIPTION
## Summary
- Fix `extractInteger` sign-stripping bug: negative integers bypassed `WithMin` and were wrongly rejected by `WithMax` (`-5` was treated as `5`).
- Rewrote `extractInteger` to read the numeric value directly via reflection (int/uint/float families) instead of fragile regex + scientific-notation string stripping.
- Removed dead `removeAfter` helper.
- Added CHANGELOG v0.0.44 entry.

## Test plan
- [x] `TestNegativeIntegerFailsWithMin` — `-5` fails `WithMin(1)`
- [x] `TestNegativeIntegerPassesWithMax` — `-5` passes `WithMax(3)`
- [x] `TestNegativeIntegerBetween` — negative range via `Between(-10,10)`
- [x] `make tests` all green (incl. existing large-int `TestInvalidLengthMessageCaseOneT`)
- [x] `go vet ./...` clean
- [x] `go test -race ./...` clean