### PR TITLE
v0.0.45: fix Default, form numeric/bool fields, unique panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to incremental patch versioning (`v0.0.x`).
 
+## [v0.0.45]
+
+A bug-fix release. No public API additions; two behavior corrections are
+non-breaking (they fix paths that previously errored or panicked).
+
+### Fixed
+
+- **`.Default(v)` now works without an explicit `.Nullable()`.** Previously `Str().Default("guest")` still errored with `"we need 'x' field"` when the field was absent, so the default was never applied. `Default` now implies the field is optional. Non-breaking: present fields behave identically, and the previously-erroring case was unusable.
+- **Integer / float / bool fields from HTTP forms now validate.** `LoadFormHttp` stored every value as a string but type coercion only ran for JSON sources, so `Int`, `Float64`, and `Bool` form fields always failed with `"should be 'int'/'bool'"` — effectively only `String` worked. Form values are now normalized (numbers → `float64`, bools → `bool`) and run through the same coercion path as JSON. `Float32`/`Float64` and the full integer family are now accepted form types. Invalid input (e.g. `"abc"` for an `Int`) still yields a clear type error.
+- **Unique check no longer panics on non-comparable values.** Comparing sibling values with `==` panicked when a field held a slice/map (e.g. via `Any()`). The comparison now uses `reflect.DeepEqual`; equal slices are still flagged as violations.
+- **`${unique_origin}` / `${unique_target}` template guard corrected.** `buildMessage` checked `meta.Field` for nil but dereferenced `meta.UniqueOrigin` / `meta.UniqueTarget` — a latent nil-deref. Now guards the correct pointers.
+
+### Internal
+
+- New `coercesNumbers(dataFrom)` helper centralizes the JSON-like-source check and includes multipart/urlencoded forms.
+- New `coerceFormValue(value, kind)` helper for form value normalization.
+- Added `test/form_test.go` (first-ever `LoadFormHttp` coverage) and regression tests: `TestDefaultImpliesNullable`, `TestUniqueNonComparableValues`.
+
+### Migration notes
+
+- No code changes required for existing callers.
+- If you declared `Int`/`Bool`/`Float` rules for form handlers and worked around them by treating everything as `String`, you can now declare the real types.
+
 ## [v0.0.44]
 
 A bug-fix release. No public API changes.

--- a/map_validator/functions.go
+++ b/map_validator/functions.go
@@ -112,13 +112,13 @@ func buildMessage(msg string, meta MessageMeta) error {
 		}
 	}
 	if strings.Contains(msg, uniqueOriginVar) {
-		if meta.Field != nil {
+		if meta.UniqueOrigin != nil {
 			v := *meta.UniqueOrigin
 			msg = strings.ReplaceAll(msg, uniqueOriginVar, v)
 		}
 	}
 	if strings.Contains(msg, uniqueTargetVar) {
-		if meta.Field != nil {
+		if meta.UniqueTarget != nil {
 			v := *meta.UniqueTarget
 			msg = strings.ReplaceAll(msg, uniqueTargetVar, v)
 		}

--- a/map_validator/functions.go
+++ b/map_validator/functions.go
@@ -421,7 +421,7 @@ func validateValueInternal(data interface{}, validator Rules, dataFrom loadFromT
 
 	// validatorType type validation
 	dataType := reflect.TypeOf(data).Kind()
-	handleIntOnHttpJson := (dataFrom == fromHttpJson || dataFrom == fromJSONEncoder) && isIntegerFamily(validator.Type) && isIntegerFamily(dataType)
+	handleIntOnHttpJson := coercesNumbers(dataFrom) && isIntegerFamily(validator.Type) && isIntegerFamily(dataType)
 	customData := !(!validator.UUID &&
 		!validator.IPV4 &&
 		!validator.UUIDToString &&
@@ -440,7 +440,7 @@ func validateValueInternal(data interface{}, validator Rules, dataFrom loadFromT
 	//}
 
 	if dataType != validator.Type && !customData && !handleIntOnHttpJson {
-		if (dataFrom == fromHttpJson || dataFrom == fromJSONEncoder) && isIntegerFamily(validator.Type) {
+		if coercesNumbers(dataFrom) && isIntegerFamily(validator.Type) {
 			validator.Type = reflect.Int
 		}
 		if validator.CustomMsg.OnTypeNotMatch != nil {
@@ -589,7 +589,7 @@ func validateValueInternal(data interface{}, validator Rules, dataFrom loadFromT
 			if it != nil && tmpRule.Type != reflect.Invalid {
 				gotKind := reflect.TypeOf(it).Kind()
 				expectedKind := tmpRule.Type
-				allowIntCoerce := (dataFrom == fromHttpJson || dataFrom == fromJSONEncoder) && isIntegerFamily(expectedKind) && isIntegerFamily(gotKind)
+				allowIntCoerce := coercesNumbers(dataFrom) && isIntegerFamily(expectedKind) && isIntegerFamily(gotKind)
 				if gotKind != expectedKind && !allowIntCoerce {
 					// Map kind to human-friendly noun (e.g., int/uint/float -> integer)
 					noun := expectedKind.String()
@@ -672,7 +672,7 @@ func validateValueInternal(data interface{}, validator Rules, dataFrom loadFromT
 			// Handle integer family coercion for HTTP JSON like regular type validation
 			if dataType != enumType.Elem().Kind() {
 				// Allow type mismatch for integer family from HTTP JSON
-				if (dataFrom == fromHttpJson || dataFrom == fromJSONEncoder) &&
+				if coercesNumbers(dataFrom) &&
 					isIntegerFamily(enumType.Elem().Kind()) && isIntegerFamily(dataType) {
 					// Type coercion will be handled in the switch cases below
 				} else {
@@ -690,7 +690,7 @@ func validateValueInternal(data interface{}, validator Rules, dataFrom loadFromT
 			}
 
 			// Handle cross-type enum validation for integer family from HTTP JSON
-			if (dataFrom == fromHttpJson || dataFrom == fromJSONEncoder) &&
+			if coercesNumbers(dataFrom) &&
 				isIntegerFamily(enumType.Elem().Kind()) && isIntegerFamily(dataType) &&
 				dataType != enumType.Elem().Kind() {
 				// Convert float64 JSON data to compare with integer family enum items
@@ -1237,6 +1237,32 @@ func isDataInList[T validatorType](key T, data []T) (result bool) {
 		}
 	}
 	return
+}
+
+// coercesNumbers reports whether values from this source arrive pre-decoded as
+// JSON-like primitives (numbers as float64, bools as bool) so integer-family
+// type coercion applies. Multipart/urlencoded form values are normalized the
+// same way in LoadFormHttp, so they qualify too.
+func coercesNumbers(dataFrom loadFromType) bool {
+	return dataFrom == fromHttpJson || dataFrom == fromJSONEncoder || dataFrom == fromHttpMultipartForm
+}
+
+// coerceFormValue normalizes a raw form string into the JSON-like primitive the
+// validator expects for the declared kind: numbers become float64 (matching the
+// JSON decoder), booleans become bool. On parse failure the raw string is
+// returned so the normal type check reports a clear "should be 'int'" error.
+func coerceFormValue(value string, kind reflect.Kind) interface{} {
+	switch {
+	case kind == reflect.Bool:
+		if b, err := strconv.ParseBool(value); err == nil {
+			return b
+		}
+	case isIntegerFamily(kind):
+		if f, err := strconv.ParseFloat(value, 64); err == nil {
+			return f
+		}
+	}
+	return value
 }
 
 func isIntegerFamily(dataType reflect.Kind) bool {

--- a/map_validator/implements.go
+++ b/map_validator/implements.go
@@ -138,35 +138,24 @@ func (state *dataState) LoadFormHttp(r *http.Request) (*finalOperation, error) {
 		}
 	}
 	mapData := map[string]interface{}{}
-	allowType := []reflect.Kind{reflect.String, reflect.Int, reflect.Bool}
 	for key, rule := range state.rules.getRules() {
-		var isAllowType bool
 		if rule.File {
 			file, fileInfo, err := r.FormFile(key)
-			if err != nil {
-				mapData[key] = nil
-			}
-			if file == nil {
+			if err != nil || file == nil {
 				mapData[key] = nil
 			} else {
 				mapData[key] = FileRequest{File: file, FileInfo: fileInfo}
 			}
+			continue
+		}
+		if rule.Type != reflect.String && rule.Type != reflect.Bool && !isIntegerFamily(rule.Type) {
+			return nil, ErrUnsupportType
+		}
+		value := r.FormValue(key)
+		if value == "" {
+			mapData[key] = nil
 		} else {
-			for _, allowItem := range allowType {
-				if rule.Type == allowItem {
-					isAllowType = true
-					break
-				}
-			}
-			if !isAllowType {
-				return nil, ErrUnsupportType
-			}
-			value := r.FormValue(key)
-			if value == "" {
-				mapData[key] = nil
-			} else {
-				mapData[key] = value
-			}
+			mapData[key] = coerceFormValue(value, rule.Type)
 		}
 	}
 	//if state.strictAllowedValue {

--- a/map_validator/shortcuts.go
+++ b/map_validator/shortcuts.go
@@ -90,8 +90,12 @@ func Any() Rules {
 // original Rules value is never mutated. Use `With*` prefix wherever the
 // method name would collide with an existing struct field.
 
-func (r Rules) Nullable() Rules             { r.Null = true; return r }
-func (r Rules) Default(v interface{}) Rules { r.IfNull = v; return r }
+func (r Rules) Nullable() Rules { r.Null = true; return r }
+
+// Default sets the value substituted when the field is absent/null. Because a
+// default only makes sense for an optional field, this also marks the rule
+// nullable so a missing field yields the default instead of a "required" error.
+func (r Rules) Default(v interface{}) Rules { r.IfNull = v; r.Null = true; return r }
 func (r Rules) WithMin(n int64) Rules       { r.Min = SetTotal(n); return r }
 func (r Rules) WithMax(n int64) Rules       { r.Max = SetTotal(n); return r }
 func (r Rules) Between(min, max int64) Rules {

--- a/map_validator/tree_chaining.go
+++ b/map_validator/tree_chaining.go
@@ -2,6 +2,7 @@ package map_validator
 
 import (
 	"fmt"
+	"reflect"
 )
 
 type chainState struct {
@@ -235,7 +236,7 @@ func (cs *chainState) RunUniqueChecker() {
 			for _, unique := range cs.uniques {
 				originKey := cs.GetKey()
 				targetKey := bro.GetKey()
-				if targetKey == unique && bro.GetValue() == cs.GetValue() {
+				if targetKey == unique && reflect.DeepEqual(bro.GetValue(), cs.GetValue()) {
 					msgError := fmt.Errorf("value of '%s' and '%s' fields must be different", originKey, targetKey)
 					if cs.CustomMsg != nil && cs.CustomMsg.uniqueNotNil() {
 						msgError = buildMessage(*cs.CustomMsg.OnUnique, MessageMeta{

--- a/test/form_test.go
+++ b/test/form_test.go
@@ -1,0 +1,151 @@
+package test
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Rhyanz46/go-map-validator/map_validator"
+)
+
+func TestForm_IntCoerced(t *testing.T) {
+	form := url.Values{}
+	form.Set("age", "30")
+	req := httptest.NewRequest("POST", "/", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	type out struct {
+		Age int `json:"age"`
+	}
+	rules := map_validator.BuildRoles().
+		SetRule("age", map_validator.Rules{Type: reflect.Int})
+
+	op, err := map_validator.NewValidateBuilder().SetRules(rules).LoadFormHttp(req)
+	if err != nil {
+		t.Fatalf("load: %s", err)
+	}
+	extra, err := op.RunValidate()
+	if err != nil {
+		t.Fatalf("expected int form value to validate, got: %s", err)
+	}
+	var o out
+	if err := extra.Bind(&o); err != nil {
+		t.Fatalf("bind: %s", err)
+	}
+	if o.Age != 30 {
+		t.Errorf("expected age 30, got %d", o.Age)
+	}
+}
+
+func TestForm_IntWithMaxAndNegative(t *testing.T) {
+	rules := map_validator.BuildRoles().
+		SetRule("n", map_validator.Int().Between(0, 100))
+
+	form := url.Values{}
+	form.Set("n", "-5")
+	req := httptest.NewRequest("POST", "/", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	op, err := map_validator.NewValidateBuilder().SetRules(rules).LoadFormHttp(req)
+	if err != nil {
+		t.Fatalf("load: %s", err)
+	}
+	if _, err = op.RunValidate(); err == nil {
+		t.Error("expected -5 to fail Between(0,100) from form, but passed")
+	}
+}
+
+func TestForm_BoolCoerced(t *testing.T) {
+	form := url.Values{}
+	form.Set("active", "true")
+	req := httptest.NewRequest("POST", "/", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	type out struct {
+		Active bool `json:"active"`
+	}
+	rules := map_validator.BuildRoles().
+		SetRule("active", map_validator.Rules{Type: reflect.Bool})
+
+	op, err := map_validator.NewValidateBuilder().SetRules(rules).LoadFormHttp(req)
+	if err != nil {
+		t.Fatalf("load: %s", err)
+	}
+	extra, err := op.RunValidate()
+	if err != nil {
+		t.Fatalf("expected bool form value to validate, got: %s", err)
+	}
+	var o out
+	if err := extra.Bind(&o); err != nil {
+		t.Fatalf("bind: %s", err)
+	}
+	if !o.Active {
+		t.Errorf("expected active true, got %v", o.Active)
+	}
+}
+
+func TestForm_FloatCoerced(t *testing.T) {
+	form := url.Values{}
+	form.Set("rate", "1.5")
+	req := httptest.NewRequest("POST", "/", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	rules := map_validator.BuildRoles().
+		SetRule("rate", map_validator.Rules{Type: reflect.Float64})
+
+	op, err := map_validator.NewValidateBuilder().SetRules(rules).LoadFormHttp(req)
+	if err != nil {
+		t.Fatalf("load: %s", err)
+	}
+	if _, err = op.RunValidate(); err != nil {
+		t.Fatalf("expected float form value to validate, got: %s", err)
+	}
+}
+
+func TestForm_InvalidIntFails(t *testing.T) {
+	form := url.Values{}
+	form.Set("age", "abc")
+	req := httptest.NewRequest("POST", "/", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	rules := map_validator.BuildRoles().
+		SetRule("age", map_validator.Rules{Type: reflect.Int})
+
+	op, err := map_validator.NewValidateBuilder().SetRules(rules).LoadFormHttp(req)
+	if err != nil {
+		t.Fatalf("load: %s", err)
+	}
+	if _, err = op.RunValidate(); err == nil {
+		t.Error("expected 'abc' to fail int validation, but passed")
+	}
+}
+
+func TestForm_StringStillWorks(t *testing.T) {
+	form := url.Values{}
+	form.Set("name", "bob")
+	req := httptest.NewRequest("POST", "/", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	type out struct {
+		Name string `json:"name"`
+	}
+	rules := map_validator.BuildRoles().
+		SetRule("name", map_validator.Str().WithMax(50))
+
+	op, err := map_validator.NewValidateBuilder().SetRules(rules).LoadFormHttp(req)
+	if err != nil {
+		t.Fatalf("load: %s", err)
+	}
+	extra, err := op.RunValidate()
+	if err != nil {
+		t.Fatalf("expected string form value to validate, got: %s", err)
+	}
+	var o out
+	if err := extra.Bind(&o); err != nil {
+		t.Fatalf("bind: %s", err)
+	}
+	if o.Name != "bob" {
+		t.Errorf("expected name bob, got %q", o.Name)
+	}
+}

--- a/test/unique_values_test.go
+++ b/test/unique_values_test.go
@@ -138,6 +138,38 @@ func TestUniqueManyValue(t *testing.T) {
 	}
 }
 
+// TestUniqueNonComparableValues: unique check must not panic when field values
+// are non-comparable (slice/map); equal values should still be flagged.
+func TestUniqueNonComparableValues(t *testing.T) {
+	rules := map_validator.BuildRoles().
+		SetRule("a", map_validator.Any()).
+		SetRule("b", map_validator.Any().UniqueFrom("a"))
+
+	check, err := map_validator.NewValidateBuilder().SetRules(rules).Load(map[string]interface{}{
+		"a": []interface{}{1, 2, 3},
+		"b": []interface{}{1, 2, 3},
+	})
+	if err != nil {
+		t.Fatalf("load error: %s", err)
+	}
+	_, err = check.RunValidate()
+	if err == nil {
+		t.Fatal("expected unique violation for equal slices, got nil")
+	}
+
+	// Different slices must pass.
+	check2, err := map_validator.NewValidateBuilder().SetRules(rules).Load(map[string]interface{}{
+		"a": []interface{}{1, 2, 3},
+		"b": []interface{}{4, 5, 6},
+	})
+	if err != nil {
+		t.Fatalf("load error: %s", err)
+	}
+	if _, err = check2.RunValidate(); err != nil {
+		t.Fatalf("expected different slices to pass, got: %s", err)
+	}
+}
+
 func TestChildUniqueValueWithCustomMsg(t *testing.T) {
 	roleChild := map_validator.BuildRoles().
 		SetRule("name", map_validator.Rules{Type: reflect.String, Null: true}).

--- a/test/validate_json_test.go
+++ b/test/validate_json_test.go
@@ -293,6 +293,25 @@ func TestValidateJSONDefaultValue(t *testing.T) {
 	}
 }
 
+// TestDefaultImpliesNullable: .Default(v) alone (no .Nullable()) must apply the
+// default on a missing field instead of erroring as required.
+func TestDefaultImpliesNullable(t *testing.T) {
+	rules := map_validator.BuildRoles().
+		SetRule("role", map_validator.Str().Default("guest"))
+
+	op, err := map_validator.NewValidateBuilder().SetRules(rules).Load(map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("load error: %s", err)
+	}
+	extra, err := op.RunValidate()
+	if err != nil {
+		t.Fatalf("expected default to apply on missing field, got error: %s", err)
+	}
+	if got := extra.GetData()["role"]; got != "guest" {
+		t.Errorf("expected default 'guest', got %v", got)
+	}
+}
+
 // TestValidateJSONListObject: ListOfObject(itemRules), body array of object,
 // tiap item ter-validasi dan ter-bind ke struct.
 func TestValidateJSONListObject(t *testing.T) {


### PR DESCRIPTION
## Summary
Bug-fix release. Four fixes, all non-breaking:

- **#1 `.Default(v)` without `.Nullable()`** — default is now applied on missing fields instead of erroring as required.
- **#2 unique-message nil guard** — `buildMessage` guarded `meta.Field` but dereferenced `meta.UniqueOrigin`/`UniqueTarget`; corrected.
- **#3 unique panic on non-comparable values** — `==` on slice/map values panicked; now uses `reflect.DeepEqual`.
- **#4 form int/float/bool fields** — `LoadFormHttp` only let `String` through; numbers/bools now coerce and validate (first-ever `LoadFormHttp` test coverage).

## Test plan
- [x] `TestDefaultImpliesNullable`
- [x] `TestUniqueNonComparableValues`
- [x] `test/form_test.go` (6 scenarios: int, between+negative, bool, float, invalid-int, string)
- [x] `make tests` all green
- [x] `go vet ./...` clean
- [x] `go test -race ./...` clean